### PR TITLE
SingleAPProb in phFunc.h was modified to include PH<PHk.

### DIFF
--- a/phFunc.h
+++ b/phFunc.h
@@ -79,12 +79,8 @@ Double_t SingleAPProb(Double_t *x,Double_t *par){
 	Double_t ped    = par[3];
 	Double_t gain   = par[4];
 	Double_t PHexp=ped+k*gain;
-	if (PH>PHexp) {
-		Double_t dom = TMath::Exp(-(PH-PHexp)/beta);
-		Double_t coeff = TMath::Sqrt(2*TMath::Pi())*sigma_k*beta;
-		Double_t inte = TMath::Sqrt(TMath::Pi()/2.)*sigma_k*TMath::Erfc(-(PH-PHexp)/TMath::Sqrt(2)/sigma_k);
-		return dom*inte/coeff;
-	}else{
-		return 0;
-	}
+	Double_t dom = TMath::Exp(-(PH-PHexp)/beta);
+	Double_t coeff = TMath::Sqrt(2*TMath::Pi())*sigma_k*beta;
+	Double_t inte = TMath::Sqrt(TMath::Pi()/2.)*sigma_k*TMath::Erfc(-(PH-PHexp)/TMath::Sqrt(2)/sigma_k);
+	return dom*inte/coeff;
 }


### PR DESCRIPTION
phFunc.h内のSingleAPProb関数はあるセルがアフターパルスを一つだけ出した場合のスペクトルをガウシアンでなまらせたものですが，なまらせる目的はノイズによるふらつきを含めることなので，PH < PHk の領域にも値を持つはずだと思います。（論文の式(8)）